### PR TITLE
Set LU_INDEX in LES initialization code

### DIFF
--- a/WRFV3/dyn_em/module_initialize_les.F
+++ b/WRFV3/dyn_em/module_initialize_les.F
@@ -210,8 +210,7 @@ CONTAINS
     mminlu2 = ' '
     mminlu2(1:4) = 'USGS'
     CALL nl_set_mminlu(1, mminlu2)
-!    CALL nl_set_mminlu(1, '    ')
-    CALL nl_set_iswater(1,0)
+    CALL nl_set_iswater(1,16)
     CALL nl_set_cen_lat(1,40.)
     CALL nl_set_cen_lon(1,-105.)
     CALL nl_set_truelat1(1,0.)
@@ -241,6 +240,11 @@ CONTAINS
 !  for LES, include Coriolis force
          grid%f(i,j)        = 1.e-4 
 
+!  for LES, initialize surface type and skin temperature
+         grid%xland(i,j)     = 1.
+         grid%landmask(i,j)  = 1.
+         grid%lu_index(i,j)  = 7
+         grid%tsk(i,j) = 280.0
       END DO
    END DO
 

--- a/WRFV3/test/em_les/namelist.input
+++ b/WRFV3/test/em_les/namelist.input
@@ -59,7 +59,7 @@
  ra_lw_physics                       = 0,     0,     0,
  ra_sw_physics                       = 0,     0,     0,
  radt                                = 0,     0,     0,
- sf_sfclay_physics                   = 0,     1,     1,
+ sf_sfclay_physics                   = 1,     1,     1,
  sf_surface_physics                  = 0,     0,     0,
  bl_pbl_physics                      = 0,     0,     0,
  bldt                                = 0,     0,     0,


### PR DESCRIPTION
Borrows idea from seabreeze2d_x test case where the land use must be specified as that particular idealized case actually relies on surface type.

Closes #13 