### PR TITLE
Fix configure/build process

### DIFF
--- a/WRFV3/Makefile
+++ b/WRFV3/Makefile
@@ -116,7 +116,7 @@ all_wrfvar :
 	fi
 	if [ $(BUFR) ] ; then \
 	  (cd var/external/bufr;  \
-	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
+	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED) $(FCCOMPAT)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
 	fi
 ### Use 'make' to avoid '-i -r' above:
 	if [ $(WAVELET) ] ; then \

--- a/WRFV3/Makefile.local.mosaic
+++ b/WRFV3/Makefile.local.mosaic
@@ -1,3 +1,3 @@
 
 FC = mpif90
-FFLAGS = -g -Idatamodules -Jdatamodules
+FFLAGS = -g -Idatamodules -Jdatamodules -fallow-argument-mismatch

--- a/WRFV3/arch/Config_new.pl
+++ b/WRFV3/arch/Config_new.pl
@@ -622,7 +622,7 @@ while ( <CONFIGURE_DEFAULTS> )
            }
        }
 
-       if ( $ENV{PMC_USE_MOSAIC} eq "1" )
+     if ( $ENV{MOSAIC} eq "1" )
        {
         $_ =~ s:CONFIGURE_MOSAIC_LIB:\$\(WRF_SRC_ROOT_DIR)/../mosaic/libmosaic.a:g ;
         $_ =~ s:CONFIGURE_MOSAIC_INCLUDE:-I\$\(WRF_SRC_ROOT_DIR)/../mosaic -I\$\(WRF_SRC_ROOT_DIR)/../mosaic/datamodules:g ;

--- a/WRFV3/arch/configure_new.defaults
+++ b/WRFV3/arch/configure_new.defaults
@@ -785,8 +785,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =     
 TRADFLAG        =      CONFIGURE_TRADFLAG

--- a/WRFV3/configure
+++ b/WRFV3/configure
@@ -598,7 +598,7 @@ fi
 if [ -n "MOSAIC" ] ; then
   if [ $MOSAIC = 1 ] ; then
     echo building WRF-PartMC with MOSAIC option
-    compileflags="${compileflags}!-DPMC_USE_MOSAIC"
+    compileflags="${compileflags}!-DPMC_USE_MOSAIC!-DPMC_USE_MOSAIC_MULTI_OPT"
   else
     compileflags="${compileflags} "
   fi
@@ -799,6 +799,27 @@ if [ $os = "Linux" -o $os = "Darwin" ]; then
   CCOMP="`type $CCOMP 2>/dev/null | awk '{print $NF}' | sed -e 's/(//g;s/)//g'`"
 
   foo=foo_$$
+
+  grep '^SFC' configure.wrf | grep -i 'gfortran' > /dev/null
+  if [ $? ]
+  then
+
+    cat > ${foo}.F << EOF
+      PROGRAM GFORTRAN_VERSION_CHECK
+        IF (__GNUC__ .GT. 9) CALL EXIT(1)
+      END PROGRAM
+EOF
+
+    gfortran -o ${foo} ${foo}.F > /dev/null 2>&1 && ./${foo}
+    if [ $? -eq 1 ]
+    then
+      sed '/^FCCOMPAT/ s/$/ -fallow-argument-mismatch -fallow-invalid-boz/' configure.wrf > configure.wrf.edit
+      mv configure.wrf.edit configure.wrf
+    fi
+    rm ${foo} ${foo}.F 2> /dev/null
+  fi
+
+
 
 cat > ${foo}.c <<EOF 
  int main(int argc, char ** argv)


### PR DESCRIPTION
Fix to handle MOSAIC library and include files correctly plus setting of multiple wavelengths for optical properties. Minor configure changes based on newer versions of WRF to handle newer compilers that complain about argument mismatches.