### PR TITLE
Fix advection of vertical momentum and vertical advection of scalars

### DIFF
--- a/WRFV3/dyn_em/module_advect_em.F
+++ b/WRFV3/dyn_em/module_advect_em.F
@@ -4359,7 +4359,7 @@ SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
 
   ENDDO
 
-   ELSE IF ( horz_order == 0 ) THEN
+   ELSE IF (vert_order == 0 ) THEN
 
       ! Just in case we want to turn vertical advection off, we can do it
 
@@ -6067,10 +6067,6 @@ ELSE IF (horz_order == 2 ) THEN
      ENDDO
 
   ENDDO
-
-   ELSE IF ( horz_order == 0 ) THEN
-
-      ! Just in case we want to turn horizontal advection off, we can do it
 
    ELSE
 

--- a/WRFV3/dyn_em/module_advect_em.F
+++ b/WRFV3/dyn_em/module_advect_em.F
@@ -4359,6 +4359,10 @@ SUBROUTINE advect_scalar   ( field, field_old, tendency,    &
 
   ENDDO
 
+   ELSE IF ( horz_order == 0 ) THEN
+
+      ! Just in case we want to turn vertical advection off, we can do it
+
    ELSE
 
       WRITE (wrf_err_message,*) ' advect_scalar_6a, v_order not known ',vert_order
@@ -4470,8 +4474,8 @@ SUBROUTINE advect_w    ( w, w_old, tendency,            &
 !  set order for the advection scheme
 
   ktf=MIN(kte,kde-1)
-  horz_order = config_flags%h_sca_adv_order
-  vert_order = config_flags%v_sca_adv_order
+  horz_order = config_flags%h_mom_adv_order
+  vert_order = config_flags%v_mom_adv_order
 
 !  here is the choice of flux operators
 
@@ -6063,6 +6067,10 @@ ELSE IF (horz_order == 2 ) THEN
      ENDDO
 
   ENDDO
+
+   ELSE IF ( horz_order == 0 ) THEN
+
+      ! Just in case we want to turn horizontal advection off, we can do it
 
    ELSE
 
@@ -12666,8 +12674,8 @@ SUBROUTINE advect_weno_w    ( w, w_old, tendency,            &
 !  set order for the advection scheme
 
   ktf=MIN(kte,kde-1)
-  horz_order = config_flags%h_sca_adv_order
-  vert_order = config_flags%v_sca_adv_order
+  horz_order = config_flags%h_mom_adv_order
+  vert_order = config_flags%v_mom_adv_order
 
 !  here is the choice of flux operators
 


### PR DESCRIPTION
`advect_w` and `advect_weno_w` set `horz_order` and `vert_order` local variables to the scalar options rather than the momentum options, which is incorrect. This causes failed model runs under certain conditions. The u and v advection subroutines properly set these. Note: This currently persists in WRF codebase.

Additionally once this was fixed, vertical advection for scalars couldn't be turned off which horizontal could. The scalar advection code can have horizontal advection off by setting `h_sca_adv_order = 0` but there didn't exist logic for vertical advection `v_sca_adv_order = 0`. This triggered an error message.