### PR TITLE
Improve doxygen comments and delete obsolete/dead code.

### DIFF
--- a/interface/wrf_pmc_trans.F90
+++ b/interface/wrf_pmc_trans.F90
@@ -75,14 +75,8 @@ contains
     !> Top-bottom domain dimension size of WRF domain.
     integer, intent(in) :: global_nz
 
-    integer :: numgas
-    integer :: ids,ide, jds,jde, kds,kde,              &
-               ims,ime, jms,jme, kms,kme,              &
-               its,ite, jts,jte, kts,kte,               &
-               ips,ipe, jps,jpe, kps,kpe
-    integer :: i,j,k, i_class
+    integer :: i, j, k, i_class
     integer :: i_start, i_end, j_start, j_end
-    integer :: nx,ny,nz
     real(kind=dp) :: t1, t2
     type(env_state_t) :: env_states_tmp(pmc_ks:pmc_ke)
 
@@ -104,6 +98,7 @@ contains
                env_states(i,k,j))
           env_states(i,k,j)%prob_vert_diffusion = 0.0d0
           call compute_diffusion_probs(grid, env_states(i,k,j))
+          ! Uncomment for reflective boundary conditions (testing)
           !call eliminate_boundary_influence(env_states(i,k,j), &
           !   global_nx, global_ny)
        end do
@@ -291,73 +286,6 @@ contains
     end do
 
   end subroutine compute_advect_probs_wrf
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Compute probabilities from upwind method fluxes
-  subroutine compute_advect_probs(grid, env_state)
-
-    !> WRF grid.
-    type(domain), intent(inout) :: grid
-    !> Environmental state.
-    type(env_state_t), intent(inout) :: env_state
-
-    integer :: i, j, k
-    real(kind=dp) :: dx, dy, dt, dz
-    real(kind=dp) :: vel, flux
-
-    env_state%prob_advection = 0.0d0
-
-    i = env_state%cell_ix
-    j = env_state%cell_iy
-    k = env_state%cell_iz
-
-    dx = grid%dx
-    dy = grid%dy
-    dz = - 1.0d0 * grid%dnw(k)
-    dt = grid%dt
-
-    ! X direction
-    ! F i+1/2
-    vel = grid%u_2(i+1,k,j) 
-    flux = (dt * (vel + abs(vel)))/(2.0d0*dx)
-    env_state%prob_advection(1,0,0,:) = flux
-
-    ! F i-1/2
-    vel = grid%u_2(i,k,j) 
-    flux = -(dt * (vel - abs(vel)))/(2.0d0*dx)
-    env_state%prob_advection(-1,0,0,:) = flux
-
-    ! Y direction
-    ! F j + 1/2
-    vel = grid%v_2(i,k,j+1) 
-    flux = (dt * (vel + abs(vel)))/(2.0d0*dy)
-    env_state%prob_advection(0,0,1,:) = flux
-
-    ! F j - 1/2
-    vel = grid%v_2(i,k,j)
-    flux = -(dt * (vel - abs(vel)))/(2.0d0*dy)
-    env_state%prob_advection(0,0,-1,:) = flux
-
-    ! Vertical advection
-    if (k == 1) then
-       vel =  -1.0d0 * grid%ww(i,k+1,j) / grid%mut(i,j)
-       flux = (dt * (vel + abs(vel)))/(2.0d0*dz)
-       env_state%prob_advection(0,1,0,:) = flux
-    else if (k == 39) then
-       vel =  - 1.0d0 * grid%ww(i,k,j) / grid%mut(i,j)
-       flux = -(dt * (vel - abs(vel)))/(2.0d0*dz)
-       env_state%prob_advection(0,-1,0,:) = flux
-    else
-       vel = - 1.0d0 * grid%ww(i,k+1,j) / grid%mut(i,j)
-       flux = (dt * (vel + abs(vel)))/(2.0d0*dz)
-       env_state%prob_advection(0,1,0,:) = flux
-       vel =  - 1.0d0 * grid%ww(i,k,j) / grid%mut(i,j)
-       flux = -(dt * (vel - abs(vel)))/(2.0d0*dz)
-       env_state%prob_advection(0,-1,0,:) = flux
-    end if
-
-  end subroutine compute_advect_probs
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -668,10 +596,16 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Eliminate the influence of the boundary condition by zeroing out
+  !> probabilities that would move particles into the boundary as well
+  !> as particles moving into the domain from boundary grid cells.
   subroutine eliminate_boundary_influence(env_state, global_nx, global_ny)
 
+    !> Environmental state to modify
     type(env_state_t), intent(inout) :: env_state
+    !> East-west domain dimension size of WRF domain.
     integer, intent(in) :: global_nx
+    !> North-south domain dimension size of WRF domain.
     integer, intent(in) :: global_ny
 
     integer :: i, j
@@ -679,11 +613,12 @@ contains
     i = env_state%cell_ix
     j = env_state%cell_iy
 
+    ! Prevent particles from flowing from the boundary to interior domain.
     if (i == 1 .or. i == global_nx .or. j == 1 .or. j ==global_ny) then
        env_state%prob_advection = 0.0d0
        env_state%prob_diffusion = 0.0d0
     end if
-    ! If we want reflection at the boundary
+    ! Reflection at the boundary so particles do not leave interior.
     if (i == 2) then
        env_state%prob_advection(-1,0,0,:) = 0.0d0
        env_state%prob_diffusion(-1,0,0,:) = 0.0d0
@@ -703,9 +638,12 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !> Normalize the probabilities to be no greater than 1
+  !> Normalize the probabilities to be no greater than 1.
   subroutine normalize_probs(env_state, i_class)
+
+    !> Environmental state.
     type(env_state_t), intent(inout) :: env_state
+    !> Aerosol weight class.
     integer, intent(in) :: i_class
 
     real(kind=dp) :: prob_sum
@@ -744,7 +682,6 @@ contains
        env_state%prob_advection(:,0,:,i_class) = &
             env_state%prob_advection(:,0,:,i_class) / (prob_sum)
     end if
-
 
     ! Check if any values are less than zero
     valid_probs = all(env_state%prob_advection(:,:,:,i_class) >= 0.0d0)

--- a/interface/wrf_pmc_trans_aero.F90
+++ b/interface/wrf_pmc_trans_aero.F90
@@ -68,7 +68,7 @@ contains
     !> Full domain of aerosol states.
     type(aero_state_t), dimension(pmc_is:pmc_ie,pmc_ks:pmc_ke,pmc_js:pmc_je), &
          intent(inout) :: aero_states
-     !> Number of grid cells for entire domain in west-east direction.
+    !> Number of grid cells for entire domain in west-east direction.
     integer, intent(in) :: global_nx
     !> Number of grid cells for entire domain in north-south direction.
     integer, intent(in) :: global_ny
@@ -1134,19 +1134,6 @@ contains
     !> Full domain of aerosol states.
     type(aero_state_t), dimension(pmc_is:pmc_ie,pmc_ks:pmc_ke,pmc_js:pmc_je), &
          intent(inout) :: aero_states
-!    integer, intent(in) :: is,ie,js,je,ks,ke
-!    !> Starting PartMC index in east-west direction.
-!    integer, intent(in) :: pmc_is
-!    !> Ending PartMC index in east-west direction.
-!    integer, intent(in) :: pmc_ie
-!    !> Starting PartMC index in vertical direction.
-!    integer, intent(in) :: pmc_ks
-!    !> Ending PartMC index in vertical direction.
-!    integer, intent(in) :: pmc_ke
-!    !> Starting PartMC index in north-south direction.
-!    integer, intent(in) :: pmc_js
-!    !> Ending PartMC index in north-south direction.
-!    integer, intent(in) :: pmc_je
     !> Number of mass points in east-west direction.
     integer, intent(in) :: global_nx
     !> Number of mass points in the north-south direction.
@@ -1368,9 +1355,6 @@ contains
 #endif
 
     ! Compare new and old number concentrations per class and group
-!    if (pmc_mpi_rank() == 981) then
-!    print*, 'starting the rebalance'
-!    end if
     do j = pmc_js,pmc_je
     do k = pmc_ks,pmc_ke
     do i = pmc_is,pmc_ie
@@ -1378,11 +1362,6 @@ contains
     do i_class = 1,n_class
       n_parts_new = num_conc_new(i,k,j,i_group,i_class) / &
            aero_states(i,k,j)%awa%weight(i_group, i_class)%magnitude !&
-!      if (pmc_mpi_rank() == 981) then
-!         print*, i,k,j,i_class,i_group, num_conc_new(i,k,j,i_group,i_class), &
-!              num_conc_old(i,k,j,i_group,i_class), n_parts_new, aero_states(i,k,j)%awa%weight(i_group, i_class)%magnitude
-!      end if
-!           / env_states(i,k,j)%rrho
       if (n_parts_new > 2.0d0 * &
          aero_states(i,k,j)%n_part_ideal(i_group, i_class)) then
          weight_ratio = n_parts_new / &
@@ -1390,33 +1369,12 @@ contains
          call aero_state_scale_weight(aero_states(i,k,j), &
               aero_data, i_group, &
               i_class, weight_ratio, .true., .true.)
-!         if (pmc_mpi_rank() == 981) then
-!         print*, 'adjusting', i,k,j, i_group, i_class, weight_ratio, &
-!              aero_state_total_particles(aero_states(i,k,j), i_group, i_class)
-!         end if
       end if
     end do
     end do
     end do
     end do
     end do
-
-!    if (pmc_mpi_rank() == 981) then
-!    print*, 'looping over cells after balancing'
-!    do j = pmc_js,pmc_je
-!    do k = pmc_ks,pmc_ke
-!    do i = pmc_is,pmc_ie
-!    do i_group = 1,n_group
-!    do i_class = 1,n_class
-!        print*, i,k,j, aero_states(i,k,j)%awa%weight(i_group, i_class)%magnitude, &
-!            aero_state_total_particles(aero_states(i,k,j), i_group, i_class), &
-!            num_conc_new(i,k,j,i_group,i_class)
-!    end do
-!    end do
-!    end do
-!    end do
-!    end do
-!    end if
 
     expected_num_conc = num_conc_new
 
@@ -1441,7 +1399,7 @@ contains
     integer, intent(in) :: pmc_ks
     !> PartMC top-bottom end of domain.
     integer, intent(in) :: pmc_ke
-    !> FIXME:
+    !> Extents of array dimensions including ghost cells.
     integer, intent(in) :: is,ie,js,je,ks,ke
     !> WRF grid.
     type(domain), intent(inout) :: grid
@@ -1451,22 +1409,21 @@ contains
     type(env_state_t), intent(in) :: env_state
     !> Number concentrations at time t+dt.
     real(kind=dp), intent(inout), dimension(is:ie,ks:ke,js:je) :: num_conc_new
-    !> 
+    !> Number of mass points in east-west direction.
     integer, intent(in) :: global_nx
-    !>
+    !> Number of mass points in the north-south direction.
     integer, intent(in) :: global_ny
-    !>
+    !> Number of mass points in the vertical direction.
     integer, intent(in) :: global_nz
     !> Environmental states
     type(env_state_t), dimension(is:ie,ks:ke,js:je), &
          intent(in) :: env_states
     !> Logical flag for periodic boundary conditions
     logical, intent(in) :: ideal
-    !>
+    !> Weight group index.
     integer, intent(in) :: i_group
-    !>
+    !> Weight class index.
     integer, intent(in) :: i_class
-
 
     integer :: i_index, j_index, k_index
     integer :: i,j,k, i_part
@@ -1934,7 +1891,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !>
+  !> General debugging for a single aerosol state.
   subroutine aero_state_debug(aero_state, max_group, max_class)
 
     type(aero_state_t), intent(in) :: aero_state
@@ -1967,7 +1924,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !>
+  !> General debugging of a column of aerosol states.
   subroutine aero_states_debug(aero_states, pmc_is, pmc_ie, pmc_ks, pmc_ke, &
        pmc_js, pmc_je)
 
@@ -2057,9 +2014,11 @@ contains
     !> Action for removal (see pmc_aero_info module for action
     !> parameters). Set to AERO_INFO_NONE to not log removal.
     integer, intent(in) :: removal_action
+    !> Environmental state of the source grid cell.
     type(env_state_t), intent(in) :: env_state_from
+    !> Environmental state of the destination grid cell.
     type(env_state_t), intent(in) :: env_state_to
-    !>
+    !> Weight class to sample.
     integer, intent(in) :: i_class
 
     integer :: n_transfer, i_transfer
@@ -2177,7 +2136,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !>
+  !> Samples particles from an aero_state for a given weight class.
   subroutine aero_state_sample_particles_by_class(aero_state_from, &
        aero_state_to, aero_data, sample_prob, removal_action, &
        rrho_source, rrho_dest, dz_source, dz_dest, i_class)
@@ -2197,7 +2156,9 @@ contains
     real(kind=dp), intent(in) :: rrho_source
     !> Inverse density of destination aero_state.
     real(kind=dp), intent(in) :: rrho_dest
+    !> Source grid cell thickness.
     real(kind=dp), intent(in) :: dz_source
+    !> Destination grid cell thickness.
     real(kind=dp), intent(in) :: dz_dest
     !> Weight class to sample.
     integer, intent(in) :: i_class

--- a/interface/wrf_pmc_trans_aero.F90
+++ b/interface/wrf_pmc_trans_aero.F90
@@ -1587,23 +1587,23 @@ contains
       pmc_ke, global_nx, global_ny, global_nz, is, ie, js, je, ks, ke, &
       config_flags)
 
-    !>
+    !> PartMC east-west start of domain.
     integer, intent(in) :: pmc_is
-    !>
+    !> PartMC east-west end of domain.
     integer, intent(in) :: pmc_ie
-    !>
+    !> PartMC north-south start of domain.
     integer, intent(in) :: pmc_js
-    !>
+    !> PartMC north-south end of domain.
     integer, intent(in) :: pmc_je
-    !>
+    !> PartMC top-bottom start of domain.
     integer, intent(in) :: pmc_ks
-    !>
+    !> PartMC top-bottom end of domain.
     integer, intent(in) :: pmc_ke
-    !>
+    !> Number of mass points in east-west direction.
     integer, intent(in) :: global_nx
-    !>
+    !> Number of mass points in the north-south direction.
     integer, intent(in) :: global_ny
-    !>
+    !> Number of mass points in the vertical direction.
     integer, intent(in) :: global_nz
     !>
     integer, intent(out) :: is
@@ -1894,11 +1894,16 @@ contains
   !> General debugging for a single aerosol state.
   subroutine aero_state_debug(aero_state, max_group, max_class)
 
+    !> Aerosol state.
     type(aero_state_t), intent(in) :: aero_state
+    !> Weight group with the most particles.
+    integer, intent(out) :: max_group
+    !> Weight class with the most particles.
+    integer, intent(out) :: max_class
 
     integer :: i_group, i_class
     integer :: n_group, n_class
-    integer :: max_val, max_group, max_class
+    integer :: max_val
     integer :: n_part
 
     n_group = aero_weight_array_n_group(aero_state%awa)


### PR DESCRIPTION
Removes commented out debugging code, removes obsolete and uncalled transport subroutine that did upwind fluxes, that was replaced by allowing WRF to handle computing the fluxes, and filled in many missing subroutine comment arguments.