### PR TITLE
Handle possible different locations for RPC header files

### DIFF
--- a/WRFV3/configure
+++ b/WRFV3/configure
@@ -1124,6 +1124,29 @@ if [ $retval -ne 0 ] ; then
   echo "*****************************************************************************"
 fi
 
+# testing for location of rpc/types.h file, used in landuse
+TIRPC_INC=$(find /usr /opt -path "*/tirpc/rpc/types.h" 2>/dev/null | head -1 | xargs dirname | xargs dirname)
+
+if [ -f /usr/include/rpc/types.h ] ; then
+  sed -e '/^CFLAGS_LOCAL/s/$/ -DRPC_TYPES=1/' configure.wrf > configure.wrf.edit
+  mv configure.wrf.edit configure.wrf
+  echo standard location of RPC
+elif [ -n "$TIRPC_INC" ] ; then
+sed -e "/^CFLAGS_LOCAL/s|\$| -DRPC_TYPES=2 -I${TIRPC_INC}|" \
+    -e "/^CC /s|\$| -I${TIRPC_INC}|" \
+    -e '/^ LIB_EXTERNAL/a\                      -ltirpc \\' \
+    configure.wrf > configure.wrf.edit
+  mv configure.wrf.edit configure.wrf
+  echo "newer location of RPC: $TIRPC_INC"
+else
+  echo "************************** W A R N I N G ************************************"
+  echo " "
+  echo "The moving nest option is not available due to missing rpc/types.h file."
+  echo "Copy landread.c.dist to landread.c in share directory to bypass compile error."
+  echo " "
+  echo "*****************************************************************************"
+fi
+
 # testing for netcdf4 IO features
 if [ -n "$NETCDF4" ] ; then
   if [ $NETCDF4 -eq 1 ] ; then

--- a/WRFV3/share/landread.c
+++ b/WRFV3/share/landread.c
@@ -65,8 +65,13 @@ int GET_LANDUSE (        float *adx,
 #ifndef MS_SUA
 # include <stdio.h>
 #endif
-#include <rpc/types.h>
-#include <rpc/xdr.h>
+#if (RPC_TYPES == 1)
+# include <rpc/types.h>
+# include <rpc/xdr.h>
+#elif (RPC_TYPES == 2)
+# include <tirpc/rpc/types.h>
+# include <tirpc/rpc/xdr.h>
+#endif
 #include <math.h>
 #ifndef MACOS
 # include <malloc.h>


### PR DESCRIPTION
This change adds automatic detection of the system RPC header location during the WRF configure process, handling both the legacy glibc location (`/usr/include/rpc`) and the modern tirpc location. When tirpc is detected, the configure script now correctly sets the necessary compile flags (`-DRPC_TYPES=2, -I<tirpc_path>`), linker flags (`-ltirpc`), and ensures these reach both the C compiler and linker. This fixes `landread.c` compilation failures on modern Linux systems where RPC support has been moved out of glibc into the separate libtirpc library.

This was configured, tested and compiled successfully on Stampede3.